### PR TITLE
From stdin

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,9 @@ can have multiple lists.
     $ boom urls github https://github.com
     Boom! "github" in "urls" is "https://github.com". Got it.
 
+    # boom <list> <name> with stdin
+    $ boom copypasta long < /tmp/multiline_file.txt
+
 ** Copy an item's value to your clipboard **
 
     $ boom github

--- a/lib/boom/command.rb
+++ b/lib/boom/command.rb
@@ -77,7 +77,8 @@ module Boom
           return delete_list(command) if major == 'delete'
           return detail_list(command) unless major
           unless minor == 'delete'
-            return add_item(command,major,minor) if minor
+            minor ||= $stdin.read
+            return add_item(command,major,minor) if minor.to_s.length > 0
             return search_list_for_item(command, major)
           end
         end


### PR DESCRIPTION
Seemed a bit awkward to add multiline snippets by either throwing in newlines or using boom edit so i added a case on snippet creation that tries to read from stdin if the minor isn't set and takes the contents (provided they are not blank) as the value for the snippet.

Example: boom copypasta long < /tmp/multiline_file.txt
