### PR TITLE
Added o shortcut for open (pure lazyness!)

### DIFF
--- a/lib/boom/command.rb
+++ b/lib/boom/command.rb
@@ -74,7 +74,7 @@ module Boom
         return help if command == 'help'
         return help if command[0] == 45 || command[0] == '-' # any - dash options are pleas for help
         return echo(major,minor) if command == 'echo' || command == 'e'
-        return open(major,minor) if command == 'open'
+        return open(major,minor) if command == 'open' || command == 'o'
 
         # if we're operating on a List
         if storage.list_exists?(command)


### PR DESCRIPTION
Heck we are lazy, so give as `boom o` as well :)

When `boom` is aliased to `b`, this is short as it can get `b o github` :)
