### PR TITLE
Fixes bug #20

### DIFF
--- a/lib/boom/platform.rb
+++ b/lib/boom/platform.rb
@@ -45,7 +45,7 @@ module Boom
       def copy(item)
         copy_command = darwin? ? "pbcopy" : "xclip -selection clipboard"
 
-        `echo '#{item.value.gsub("\'","\\'")}' | tr -d "\n" | #{copy_command}`
+        Kernel.system("echo '#{item.value.gsub("\'","\\'")}' | tr -d \"\n\" | #{copy_command}")
 
         "Boom! We just copied #{item.value} to your clipboard."
       end


### PR DESCRIPTION
I've just replaced the `` with Kernel.system, and everything work fine on Ubuntu 64bit.

However I've a failing test, but I don't think this it is my fault:

  1) Failure:
test_show_storage(TestCommand)
    [./test/test_command.rb:151:in `test_show_storage'
     /home/matteo/.rvm/gems/ruby-1.8.7-p302@boom/gems/mocha-0.9.12/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in`**send**'
     /home/matteo/.rvm/gems/ruby-1.8.7-p302@boom/gems/mocha-0.9.12/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb:22:in `run']:
<"You're currently using JSON."> expected to be =~
</You're currently using json/>.
