### PR TITLE
Color + Windows = Pretty

### DIFF
--- a/lib/boom/color.rb
+++ b/lib/boom/color.rb
@@ -20,7 +20,9 @@ module Boom
     #
     # Returns nothing.
     def self.included(other)
-      require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /win32/
+      if RUBY_PLATFORM =~ /win32/ || RUBY_PLATFORM =~ /mingw32/
+        require 'Win32/Console/ANSI'
+      end
     rescue LoadError
       # Oh well, we tried.
     end


### PR DESCRIPTION
Just updated the conditional for checking if RUBY_PLATFORM is `mingw32`, as that's what the RubyInstaller platform is. Works with colours on PowerShell and cmd.exe.
