### PR TITLE
On Mac OS, if the snippet contained a parenthesis, the system command wou

### DIFF
--- a/lib/boom/platform.rb
+++ b/lib/boom/platform.rb
@@ -78,7 +78,7 @@ module Boom
         unless windows?
           system("printf '#{item.value.gsub("\'","\\'")}' | #{copy_command}")
         else
-          system("echo #{item.value.gsub("\'","\\'")} | #{copy_command}")
+          system("echo \"#{item.value.gsub("\'","\\'")}\" | #{copy_command}")
         end
 
         item.value


### PR DESCRIPTION
On Mac OS, if the snippet contained a parenthesis, the system command would fail. If you wrap the snippet in quotes, this isn't a problem.
