### PR TITLE
HTTParty should only be a soft dependency

### DIFF
--- a/lib/boom/storage/gist.rb
+++ b/lib/boom/storage/gist.rb
@@ -21,28 +21,24 @@
 #     any value other than boolean true will make
 #     the Gist private.
 #
-begin
-  require "httparty"
-rescue LoadError
-  puts "The Gist backend requires HTTParty: gem install httparty"
-  exit
-end
-
-# Crack's parsing is no bueno. Use the MultiJson instead.
-class JsonParser < HTTParty::Parser
-  def json
-    MultiJson.decode(body)
-  end
-end
 
 module Boom
   module Storage
     class Gist < Base
-      include HTTParty
-      parser JsonParser
-      base_uri "https://api.github.com"
 
       def bootstrap
+        begin
+          require "httparty"
+          require "boom/storage/gist/json_parser"
+
+          self.class.send(:include, HTTParty)
+          self.class.parser JsonParser
+          self.class.base_uri "https://api.github.com"
+        rescue LoadError
+          puts "The Gist backend requires HTTParty: gem install httparty"
+          exit
+        end
+
         unless Boom.config.attributes["gist"]
           puts 'A "gist" data structure must be defined in ~/.boom.conf'
           exit

--- a/lib/boom/storage/gist/json_parser.rb
+++ b/lib/boom/storage/gist/json_parser.rb
@@ -1,0 +1,8 @@
+# coding: utf-8
+
+# Crack's parsing is no bueno. Use the MultiJson instead.
+class JsonParser < HTTParty::Parser
+  def json
+    MultiJson.decode(body)
+  end
+end


### PR DESCRIPTION
Because the Gist backend is required from the main file, any usage of Boom required HTTParty to be present, even if you weren't using the Gist backend. This change moves the HTTParty initialization into the backend's bootstrap method (and a support file for the custom JsonParser class, which in turn can be removed once John gets around to merging [this](https://github.com/jnunemaker/httparty/pull/89).) HTTParty will now attempt to load only when the Gist backend is actually being used.
