### PR TITLE
Remove custom JSONParser because HTTParty no longer relies on Crack.

### DIFF
--- a/lib/boom/storage/gist.rb
+++ b/lib/boom/storage/gist.rb
@@ -29,10 +29,8 @@ module Boom
       def bootstrap
         begin
           require "httparty"
-          require "boom/storage/gist/json_parser"
 
           self.class.send(:include, HTTParty)
-          self.class.parser JsonParser
           self.class.base_uri "https://api.github.com"
         rescue LoadError
           puts "The Gist backend requires HTTParty: gem install httparty"

--- a/lib/boom/storage/gist/json_parser.rb
+++ b/lib/boom/storage/gist/json_parser.rb
@@ -1,8 +1,0 @@
-# coding: utf-8
-
-# Crack's parsing is no bueno. Use the MultiJson instead.
-class JsonParser < HTTParty::Parser
-  def json
-    MultiJson.decode(body)
-  end
-end


### PR DESCRIPTION
John finally [merged this pull request](https://github.com/jnunemaker/httparty/commit/7788ac947925d722f52fa6c8d66f740bf26c7e32) which switches HTTParty from Crack to MultiJSON/MultiXML for parsing. As such, the custom parser class I was using in the Gist backend for Boom is no longer needed.
