### PR TITLE
Adds graceful degradation on windows.

### DIFF
--- a/lib/boom/color.rb
+++ b/lib/boom/color.rb
@@ -33,8 +33,14 @@ module Boom
     #   colorize("Boom!", :magenta)
     #   # => "\e[35mBoom!\e[0m"
     #
-    # Returns the wrapped String.
+    # Returns the wrapped String unless the the platform is windows and
+    # does not have Win32::Console, in which case, returns the String.
     def colorize(string, color_code)
+      if !defined?(Win32::Console) && !!(RUBY_PLATFORM =~ /win32/ || RUBY_PLATFORM =~ /mingw32/)
+        # looks like this person doesn't have Win32::Console and is on windows
+        # just return the uncolorized string
+        return string
+      end
       "#{CODES[color_code] || color_code}#{string}#{CODES[:reset]}"
     end
 


### PR DESCRIPTION
Here, if the user is on windows and Win32::Console is not loaded, Colorize will just return the string, so the console doesn't have random ANSI color codes showing up.
