### PR TITLE
removed non existent file from gemspec

### DIFF
--- a/boom.gemspec
+++ b/boom.gemspec
@@ -89,7 +89,6 @@ Gem::Specification.new do |s|
     lib/boom/storage.rb
     lib/boom/storage/base.rb
     lib/boom/storage/gist.rb
-    lib/boom/storage/gist/json_parser.rb
     lib/boom/storage/json.rb
     lib/boom/storage/keychain.rb
     lib/boom/storage/mongodb.rb


### PR DESCRIPTION
Trying to install boom from git (using Bundler and a gem file) fails otherwise.
