### PR TITLE
Fix bash completion to handle spaces and special characters

### DIFF
--- a/completion/boom.bash
+++ b/completion/boom.bash
@@ -1,23 +1,17 @@
 _boom_complete() {
-    local cur prev lists
+    local cur prev lists curr_list items
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
+    curr_list=`eval echo "$prev"`
+    local IFS=$'\n'
 
-    lists=`boom | awk '{print $1}'`
-
-    case "${prev}" in
-      boom)
-        COMPREPLY=( $(compgen -W "${lists}" -- ${cur}) )
-        return 0
-        ;;
-      *)
-        for ((i = 0; i < ${#lists}; i++)); do
-          local items=`boom $prev | awk '{print $1}' | sed -e 's/://'`
-          COMPREPLY=( $(compgen -W "${items}" -- ${cur}))
-          return 0
-        done
-        ;;
-    esac
+    if [ $COMP_CWORD -eq 1 ]; then
+        lists=`boom | sed 's/^  \(.*\) ([0-9]\+)$/\1/'`
+        COMPREPLY=( $( compgen -W '${lists}' -- ${cur} ) )
+    elif [ $COMP_CWORD -eq 2 ]; then
+        items=`boom $curr_list | sed 's/^    \(.\{0,16\}\):.*$/\1/'`
+        COMPREPLY=( $( compgen -W '${items}' -- ${cur} ) )
+    fi
 }
-complete -F _boom_complete boom
+complete -o filenames -F _boom_complete boom


### PR DESCRIPTION
The current bash completion script doesn't handle spaces or special characters correctly.

An example:

``` bash
$ boom "my list"
Boom! Created a new list called my list.

$ boom <tab>
my
```

Another:

``` bash
$ boom '$$$'
Boom! Created a new list called $$$.

$ boom <tab>
30666$
```

The script now uses a regex to parse each line of output instead of splitting out single words with awk. It's a bit harder to read, but should handle all cases correctly - assuming the output format doesn't change.
