### PR TITLE
Fix some edge cases with deleting items

### DIFF
--- a/lib/boom/command.rb
+++ b/lib/boom/command.rb
@@ -108,11 +108,11 @@ module Boom
           end
         end
 
-        return search_items(command) if storage.item_exists?(command)
-
         if minor == 'delete' and storage.item_exists?(major)
           return delete_item(command, major)
         end
+
+        return search_items(command) if storage.item_exists?(command)
 
         return create_list(command, major, stdin.read) if !minor && stdin.stat.size > 0
         return create_list(command, major, minor)

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -220,4 +220,14 @@ class TestCommand < Test::Unit::TestCase
     assert_match /github not found in urlz/, command('urlz github delete')
   end
 
+  def test_delete_item_different_name
+    command('foo bar baz')
+    assert_match /bar is gone forever/, command('foo bar delete')
+  end
+
+  def test_delete_item_same_name
+    command('duck duck goose')
+    assert_match /duck is gone forever/, command('duck duck delete')
+  end
+
 end


### PR DESCRIPTION
Trying to delete an item from a nonexistent list causes an exception:

``` bash
$ boom urls github https://github.com
Boom! Created a new list called urls.
Boom! github in urls is https://github.com. Got it.

$ boom urlz guthub delete
/var/lib/gems/1.9.1/gems/boom-0.2.3/lib/boom/command.rb:277:in `delete_item': undefined method `delete_item' for nil:NilClass (NoMethodError)
# snip stacktrace
```

Trying to delete an item from the wrong list gives a misleading message:

``` bash
$ boom urls github https://github.com
Boom! Created a new list called urls.
Boom! github in urls is https://github.com. Got it.

$ boom urlz twitter https://twitter.com
Boom! Created a new list called urlz.
Boom! twitter in urlz is https://twitter.com. Got it.

$ boom urlz guthub delete
Boom! github in urlz is gone forever.
```

Deleting an item in a list with the same name doesn't work:

``` bash
$ boom duck duck goose
Boom! Created a new list called duck.
Boom! duck in duck is goose. Got it.

$ boom duck duck delete
Boom! We just copied goose to your clipboard.
```
