### PR TITLE
accept 'user', 'password', or 'uri' for redis connection

### DIFF
--- a/lib/boom/storage/redis.rb
+++ b/lib/boom/storage/redis.rb
@@ -5,6 +5,7 @@
 begin
   require 'digest'
   require 'redis'
+  require 'uri'
 rescue LoadError
 end
 
@@ -13,8 +14,12 @@ module Boom
     class Redis < Base
 
       def redis
-        @redis ||= ::Redis.new :host => Boom.config.attributes["redis"]["host"],
-                               :port => Boom.config.attributes["redis"]["port"]
+        uri = URI.parse(Boom.config.attributes['uri'] || '')
+
+        @redis ||= ::Redis.new :host     => (uri.host     || Boom.config.attributes["redis"]["host"]),
+                               :port     => (uri.port     || Boom.config.attributes["redis"]["port"]),
+                               :user     => (uri.user     || Boom.config.attributes["redis"]["user"]),
+                               :password => (uri.password || Boom.config.attributes["redis"]["password"])
       rescue NameError => e
         puts "You don't have Redis installed yet:\n  gem install redis"
         exit


### PR DESCRIPTION
This commit also allows you to specify the `user` and/or `password` for the redis connection or alternatively specify the `uri` to use for the connection. (example: redistogo)
