### PR TITLE
Make bash completion script work on Macs

### DIFF
--- a/completion/boom.bash
+++ b/completion/boom.bash
@@ -7,7 +7,7 @@ _boom_complete() {
     local IFS=$'\n'
 
     if [ $COMP_CWORD -eq 1 ]; then
-        lists=`boom | sed 's/^  \(.*\) ([0-9]\+)$/\1/'`
+        lists=`boom | sed 's/^  \(.*\) ([0-9]\{1,\})$/\1/'`
         COMPREPLY=( $( compgen -W '${lists}' -- ${cur} ) )
     elif [ $COMP_CWORD -eq 2 ]; then
         items=`boom $curr_list | sed 's/^    \(.\{0,16\}\):.*$/\1/'`


### PR DESCRIPTION
I started using a Mac for development recently, and boom's bash completion script didn't work there at all.

The problem was that `sed` on a Mac only accepts "basic" regexes; the completion script was using the one-or-more operator `+`, which is only available in "extended" regexes. I replaced the `+` with the uglier but more compatible `{1,}` and the script now works.
