### PR TITLE
Fix for boom issue #102 if empty .boom file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /pkg
+test/examples/empty.json

--- a/lib/boom/storage.rb
+++ b/lib/boom/storage.rb
@@ -77,7 +77,7 @@ module Boom
     #
     # Return true if successfully saved.
     def bootstrap
-      return if File.exist?(json_file)
+      return if File.exist?(json_file) and !File.zero?(json_file)
       FileUtils.touch json_file
       File.open(json_file, 'w') {|f| f.write(to_json) }
       save

--- a/test/list.sh
+++ b/test/list.sh
@@ -33,3 +33,10 @@ it_handles_delete_on_nonexistent_list() {
   ! $boom | grep "enemies"
   $boom delete "enemies" | grep "We couldn't find that list"
 }
+
+it_handles_empty_boomfile() {
+  cp /dev/null test/examples/empty.json
+  export BOOMFILE=test/examples/empty.json
+  $boom heynow | grep "Created a new list"
+  export BOOMFILE=test/examples/data.json
+}  


### PR DESCRIPTION
I noticed Issue #102...  if the .boom file is empty, boom barfs.
Might be edge case-ish, but added a test and fix

Note, the test addition does a switcheroo to point to a blank .boom file and reverts back
(slightly hacky but tests the scenario)

Cheers
