### PR TITLE
Add more validation around boom file

### DIFF
--- a/lib/boom/storage.rb
+++ b/lib/boom/storage.rb
@@ -89,7 +89,17 @@ module Boom
     # Returns nothing.
     def populate
       file = File.new(json_file, 'r')
-      storage = Yajl::Parser.parse(file)
+      begin
+        storage = Yajl::Parser.parse(file)
+      rescue Yajl::ParseError
+        puts "Looks like your boom file (#{json_file}) is corrupted."
+        exit
+      end
+
+      if storage.nil? or storage.empty?
+        puts "Looks like your boom file (#{json_file}) is empty."
+        exit
+      end
 
       storage['lists'].each do |lists|
         lists.each do |list_name, items|


### PR DESCRIPTION
This adds some validation around the boom file. We make sure it contains valid JSON and also make sure it is not empty. PR #103 makes sure we create the file if it's totally empty but in case there's some end of file data or just a space this makes sure we're not calling a method on a nil object (storage in this case). 

There's no test yet but I plan to do some. Opening this PR to get some initial feedback (eg. is this really needed?)
