### PR TITLE
Allowed to install yajl-1.3, so it can work on Ruby2.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     boom (0.4.0)
-      yajl-ruby (~> 1.1.0)
+      yajl-ruby (~> 1.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
     mocha (0.9.12)
     rake (0.9.2)
-    yajl-ruby (1.1.0)
+    yajl-ruby (~> 1.1)
 
 PLATFORMS
   ruby

--- a/boom.gemspec
+++ b/boom.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
 
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
-  s.add_dependency('yajl-ruby', "~> 1.1.0")
+  s.add_dependency('yajl-ruby', "~> 1.1")
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development


### PR DESCRIPTION
On Ruby 2.4, you need yajl 1.3, with this change that can be installed.

note: I have 0 experience with building Gems, so I'm not sure this works as I think it works, but at least it works on my machine 😛 